### PR TITLE
Ignore JetBrains IDE Auto-Generated Folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 ##
 ## Get latest from https://github.com/github/gitignore/blob/master/VisualStudio.gitignore
 
+# General JetBrains IDE auto-generated files
+.idea/
+
 # User-specific files
 *.rsuser
 *.suo


### PR DESCRIPTION
Ignores the `.idea/` folder for anyone using a JetBrains IDE (namely Rider).