### PR TITLE
Add Solution File

### DIFF
--- a/DragonLens.sln
+++ b/DragonLens.sln
@@ -1,0 +1,14 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/DragonLens.sln
+++ b/DragonLens.sln
@@ -3,6 +3,8 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.0.31903.59
 MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DragonLens", "DragonLens.csproj", "{8A2D7075-C645-459C-A52C-CBCA3DF405F8}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -10,5 +12,11 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{8A2D7075-C645-459C-A52C-CBCA3DF405F8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8A2D7075-C645-459C-A52C-CBCA3DF405F8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8A2D7075-C645-459C-A52C-CBCA3DF405F8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8A2D7075-C645-459C-A52C-CBCA3DF405F8}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
Add a solution file, which is supported by most major IDEs, incompatible text editors can still use the `.csproj`. Useful especially if other projects are ever introduced or if solution files are ever to be utilized. Generally no point in not having one, standard for C# projects.