### PR TITLE
Use OS-Specific dotnet Path

### DIFF
--- a/DragonLens.csproj
+++ b/DragonLens.csproj
@@ -7,6 +7,21 @@
     <PlatformTarget>AnyCPU</PlatformTarget>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
+  <PropertyGroup>
+    <!-- Set the correct dotnet path to use based on platform. On Windows, it's
+         dotnet.exe, on Linux it's dotnet. Unsure of the path on Mac. If there
+         is ever a need to differentiate, switch to using
+         $([MSBuild]::IsOSPlatform('PLATFORM_HERE')) instead.
+         
+         This is needed because, despite Visual Studio handling extensions,
+         editors such as Rider do not. A more fully-qualified name has to be
+         given instead. -->
+    <DotNetPath Condition=" '$(OS)' == 'Windows_NT' ">dotnet.exe</DotNetPath>
+    <DotNetPath Condition=" '$(OS)' == 'Unix' ">dotnet</DotNetPath>
+    
+    <!-- Fallback. -->
+    <DotNetPath Condition=" '$(DotNetPath)' == '' ">dotnet</DotNetPath>
+  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="tModLoader.CodeAssist" Version="0.1.*" />
   </ItemGroup>

--- a/Properties/launchSettings.json
+++ b/Properties/launchSettings.json
@@ -2,13 +2,13 @@
   "profiles": {
     "Terraria": {
       "commandName": "Executable",
-      "executablePath": "dotnet",
+      "executablePath": "$(DotNetPath)",
       "commandLineArgs": "$(tMLPath)",
       "workingDirectory": "$(tMLSteamPath)"
     },
     "TerrariaServer": {
       "commandName": "Executable",
-      "executablePath": "dotnet",
+      "executablePath": "(DotNetPath)",
       "commandLineArgs": "$(tMLServerPath)",
       "workingDirectory": "$(tMLSteamPath)"
     }


### PR DESCRIPTION
*See my comment in `DragonLens.csproj` for finer details of the problem and solution.*

## The Problem

Editors such as Rider do not automatically handle paths like Visual Studio does, so launching with `dotnet` on Windows will not work because the file is actually `dotnet.exe`.

## The Solution

Check the current operating system and change the path accordingly (done in the project file).