### PR TITLE
Use FixedUIScrollbar in Browser

### DIFF
--- a/Content/GUI/Browser.cs
+++ b/Content/GUI/Browser.cs
@@ -9,6 +9,7 @@ using Terraria.GameContent.UI.Elements;
 using Terraria.ModLoader;
 using Terraria.ModLoader.UI.Elements;
 using Terraria.UI;
+using FixedUIScrollbar = Terraria.GameContent.UI.Elements.FixedUIScrollbar;
 
 namespace DragonLens.Content.GUI
 {
@@ -16,7 +17,7 @@ namespace DragonLens.Content.GUI
 	{
 		private UIGrid options;
 		private UIImageButton closeButton;
-		private UIScrollbar scrollBar;
+		private FixedUIScrollbar scrollBar;
 
 		public Vector2 basePos;
 
@@ -66,7 +67,7 @@ namespace DragonLens.Content.GUI
 			closeButton.OnClick += (a, b) => visible = false;
 			Append(closeButton);
 
-			scrollBar = new();
+			scrollBar = new(UserInterface);
 			scrollBar.Width.Set(24, 0);
 			scrollBar.Height.Set(480, 0);
 			Append(scrollBar);

--- a/Core/Loaders/UILoading/SmartUIState.cs
+++ b/Core/Loaders/UILoading/SmartUIState.cs
@@ -5,6 +5,8 @@ namespace DragonLens.Core.Loaders.UILoading
 {
 	public abstract class SmartUIState : UIState
 	{
+		protected internal virtual UserInterface UserInterface { get; set; }
+		
 		public abstract int InsertionIndex(List<GameInterfaceLayer> layers);
 
 		public virtual bool Visible { get; set; } = false;

--- a/Core/Loaders/UILoading/UILoader.cs
+++ b/Core/Loaders/UILoading/UILoader.cs
@@ -27,6 +27,7 @@ namespace DragonLens.Core.Loaders.UILoading
 					var state = (SmartUIState)Activator.CreateInstance(t, null);
 					var userInterface = new UserInterface();
 					userInterface.SetState(state);
+					state.UserInterface = userInterface;
 
 					UIStates?.Add(state);
 					UserInterfaces?.Add(userInterface);


### PR DESCRIPTION
*Resolves #7.*

## The Problem

`UIGrid` does not play nice with a regular `Scrollbar`.

## The Solution

Use `FixedScrollbar` instead.

## Notes

I had to make the choice between using `Terraria.GameContent.UI.Elements.FixedUIScrollbar` and `Terraria.ModLoader.UI.Elements.FixedScrollbar`. I opted for the vanilla type since that has actual official support. It seems that vanilla faced a similar situation in 1.4 that required this. Vanilla and tModLoader use identical logic in their implementations.

Furthermore, I made changes to the loading of `SmartUIState`s to expose their associated `UserInterface` as `FixedUIScrollbar` requires it.