### PR TITLE
Replace `DragonLens.instance` With `ModContent.GetInstance<DragonLens>()`

### DIFF
--- a/Core/Systems/ToolSystem/ToolHandler.cs
+++ b/Core/Systems/ToolSystem/ToolHandler.cs
@@ -19,7 +19,7 @@ namespace DragonLens.Core.Systems.ToolSystem
 
 		public static Tool GetTool(string typeString)
 		{
-			Type type = DragonLens.instance.Code.GetType(typeString);
+			Type type = ModContent.GetInstance<DragonLens>().Code.GetType(typeString);
 			return toolsByType[type];
 		}
 

--- a/DragonLens.cs
+++ b/DragonLens.cs
@@ -4,11 +4,5 @@ namespace DragonLens
 {
 	public class DragonLens : Mod
 	{
-		public static DragonLens instance;
-
-		public override void Load()
-		{
-			instance = this;
-		}
 	}
 }


### PR DESCRIPTION
tML's `ModContent.GetInstance<T>` API is sufficient for retrieving mod instances.

On a slightly unrelated note, making this PR has exposed an issue that needs addressing--mods cannot add their own tools as of now due to this.