### PR TITLE
Browser opening freeze reduced

### DIFF
--- a/Content/Tools/CustomizeTool.cs
+++ b/Content/Tools/CustomizeTool.cs
@@ -3,6 +3,7 @@ using DragonLens.Core.Loaders.UILoading;
 using DragonLens.Core.Systems.ToolbarSystem;
 using DragonLens.Core.Systems.ToolSystem;
 using Microsoft.Xna.Framework.Graphics;
+using System.Collections.Generic;
 using System.IO;
 using Terraria;
 using Terraria.ModLoader.UI.Elements;
@@ -51,10 +52,12 @@ namespace DragonLens.Content.Tools
 
 		public override void PopulateGrid(UIGrid grid)
 		{
+			List<ToolBrowserButton> buttons = new List<ToolBrowserButton>();
 			for (int k = 0; k < ToolHandler.tools.Count; k++)
 			{
-				grid.Add(new ToolBrowserButton(ToolHandler.tools[k]));
+				buttons.Add(new ToolBrowserButton(ToolHandler.tools[k]));
 			}
+			grid.AddRange(buttons);
 		}
 
 		public static void OpenForToolbar(ToolbarElement bar)

--- a/Content/Tools/Spawners/ItemSpawner.cs
+++ b/Content/Tools/Spawners/ItemSpawner.cs
@@ -2,6 +2,7 @@
 using DragonLens.Core.Loaders.UILoading;
 using DragonLens.Core.Systems.ToolSystem;
 using Microsoft.Xna.Framework.Graphics;
+using System.Collections.Generic;
 using Terraria;
 using Terraria.ModLoader;
 using Terraria.ModLoader.UI.Elements;
@@ -38,13 +39,15 @@ namespace DragonLens.Content.Tools.Spawners
 
 		public override void PopulateGrid(UIGrid grid)
 		{
+			List<ItemButton> buttons = new List<ItemButton>();
 			for (int k = 0; k < ItemLoader.ItemCount; k++)
 			{
 				var item = new Item();
 				item.SetDefaults(k);
 
-				grid.Add(new ItemButton(item));
+				buttons.Add(new ItemButton(item));
 			}
+			grid.AddRange(buttons);
 		}
 	}
 

--- a/Content/Tools/Spawners/NPCSpawner.cs
+++ b/Content/Tools/Spawners/NPCSpawner.cs
@@ -3,6 +3,11 @@ using DragonLens.Core.Loaders.UILoading;
 using DragonLens.Core.Systems.ToolSystem;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
 using Terraria;
 using Terraria.GameContent.Bestiary;
 using Terraria.ModLoader;
@@ -42,14 +47,16 @@ namespace DragonLens.Content.Tools.Spawners
 
 		public override void PopulateGrid(UIGrid grid)
 		{
+			List<NPCButton> buttons = new List<NPCButton>();
 			for (int k = 0; k < NPCLoader.NPCCount; k++)
 			{
 				var npc = new NPC();
 				npc.SetDefaults(k);
 
-				grid.Add(new NPCButton(npc));
+				buttons.Add(new NPCButton(npc));
 			}
-		}
+			grid.AddRange(buttons);//causes most of the delay
+	}
 
 		public override void Click(UIMouseEvent evt)
 		{

--- a/Content/Tools/Spawners/ProjectileSpawner.cs
+++ b/Content/Tools/Spawners/ProjectileSpawner.cs
@@ -4,6 +4,8 @@ using DragonLens.Core.Systems.ToolSystem;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
 using Terraria;
 using Terraria.ModLoader;
 using Terraria.ModLoader.UI.Elements;
@@ -44,13 +46,15 @@ namespace DragonLens.Content.Tools.Spawners
 
 		public override void PopulateGrid(UIGrid grid)
 		{
+			List<ProjectileButton> buttons = new List<ProjectileButton>();
 			for (int k = 0; k < ProjectileLoader.ProjectileCount; k++)
 			{
 				var proj = new Projectile();
 				proj.SetDefaults(k);
 
-				grid.Add(new ProjectileButton(proj));
+				buttons.Add(new ProjectileButton(proj));
 			}
+			grid.AddRange(buttons);
 		}
 
 		public override void Click(UIMouseEvent evt)


### PR DESCRIPTION
Dramatically reduces the game freeze when opening a browser menu by using `UIGrid.AddRange` instead of `UIGrid.Add` (which resorts the entire list every time an item is added)
I also tried using seperate threads to farther increase performance, but AddRange still caused a game freeze so performance gain was negligible.