### PR TITLE
Remove Extra "damage" Text in Damage Filters

### DIFF
--- a/Content/Filters/ItemFilters/DamageClassFilter.cs
+++ b/Content/Filters/ItemFilters/DamageClassFilter.cs
@@ -8,7 +8,7 @@ namespace DragonLens.Content.Filters.ItemFilters
 	{
 		public DamageClass damageClass;
 
-		public DamageClassFilter(DamageClass damageClass, string texture) : base(texture, damageClass.DisplayName, $"Items with {damageClass.DisplayName} damage", n => FilterByDamageClass(n, damageClass))
+		public DamageClassFilter(DamageClass damageClass, string texture) : base(texture, damageClass.DisplayName, $"Items with {damageClass.DisplayName}", n => FilterByDamageClass(n, damageClass))
 		{
 			this.damageClass = damageClass;
 		}


### PR DESCRIPTION
*Resolves #19.*

Fixes an issue with damage filters where "damage" was appended to the end despite display names already handling that.

This is fine for now, but it may be worthwhile to look into other ways of displaying the damage class name in a manner more consistent with other filters.