### PR TITLE
Fix Erroneous Starting Spawner Indexes & Add Deprecated items to Item Spawner

### DIFF
--- a/Content/Tools/Spawners/BuffSpawner.cs
+++ b/Content/Tools/Spawners/BuffSpawner.cs
@@ -69,7 +69,9 @@ namespace DragonLens.Content.Tools.Spawners
 		public override void PopulateGrid(UIGrid grid)
 		{
 			var buttons = new List<BuffButton>();
-			for (int k = 0; k < BuffLoader.BuffCount; k++)
+			// `0` doesn't correspond to anything - not even BuffID.None (which
+			// doesn't exist). ObsidianSkin is the first buff in the game (`1`).
+			for (int k = BuffID.ObsidianSkin; k < BuffLoader.BuffCount; k++)
 			{
 				buttons.Add(new BuffButton(k, this));
 			}

--- a/Content/Tools/Spawners/BuffSpawner.cs
+++ b/Content/Tools/Spawners/BuffSpawner.cs
@@ -71,7 +71,7 @@ namespace DragonLens.Content.Tools.Spawners
 			var buttons = new List<BuffButton>();
 			// `0` doesn't correspond to anything - not even BuffID.None (which
 			// doesn't exist). ObsidianSkin is the first buff in the game (`1`).
-			for (int k = BuffID.ObsidianSkin; k < BuffLoader.BuffCount; k++)
+			for (int k = 1; k < BuffLoader.BuffCount; k++)
 			{
 				buttons.Add(new BuffButton(k, this));
 			}

--- a/Content/Tools/Spawners/ItemSpawner.cs
+++ b/Content/Tools/Spawners/ItemSpawner.cs
@@ -46,6 +46,9 @@ namespace DragonLens.Content.Tools.Spawners
 
 		public override void PopulateGrid(UIGrid grid)
 		{
+			bool[] deprecated = ItemID.Sets.Deprecated;
+			ItemID.Sets.Deprecated = ItemID.Sets.Factory.CreateBoolSet();
+			
 			var buttons = new List<ItemButton>();
 			// `0` corresponds to ItemID.None - that is, no item.
 			for (int k = ItemID.IronPickaxe; k < ItemLoader.ItemCount; k++)
@@ -57,6 +60,8 @@ namespace DragonLens.Content.Tools.Spawners
 			}
 
 			grid.AddRange(buttons);
+			
+			ItemID.Sets.Deprecated = deprecated;
 		}
 
 		public override void SetupFilters(FilterPanel filters)
@@ -81,6 +86,7 @@ namespace DragonLens.Content.Tools.Spawners
 			filters.AddFilter(new Filter("DragonLens/Assets/GUI/NoBox", "Accessory", "Any item that can be equipped as an accessory", n => !(n is ItemButton && (n as ItemButton).item.accessory)));
 			filters.AddFilter(new Filter("DragonLens/Assets/GUI/NoBox", "Armor", "Any item that can be equipped as armor", n => !(n is ItemButton && (n as ItemButton).item.defense > 0)));
 			filters.AddFilter(new Filter("DragonLens/Assets/GUI/NoBox", "Placeable", "Any item that palces a tile", n => !(n is ItemButton && (n as ItemButton).item.createTile >= 0)));
+			filters.AddFilter(new Filter("DragonLens/Assets/GUI/NoBox", "Deprecated", "Any item that is deprecated (ItemID.Sets.Deprecated)", n => n is ItemButton ib && !ItemID.Sets.Deprecated[ib.item.type]));
 		}
 	}
 

--- a/Content/Tools/Spawners/ItemSpawner.cs
+++ b/Content/Tools/Spawners/ItemSpawner.cs
@@ -46,6 +46,10 @@ namespace DragonLens.Content.Tools.Spawners
 
 		public override void PopulateGrid(UIGrid grid)
 		{
+			// Clear deprecated items set during loading to allow them to get
+			// their defaults set correctly + allow them to be accessed through
+			// the spawner. The set is stored and restored after the grid is
+			// populated.
 			bool[] deprecated = ItemID.Sets.Deprecated;
 			ItemID.Sets.Deprecated = ItemID.Sets.Factory.CreateBoolSet();
 			

--- a/Content/Tools/Spawners/ItemSpawner.cs
+++ b/Content/Tools/Spawners/ItemSpawner.cs
@@ -55,7 +55,7 @@ namespace DragonLens.Content.Tools.Spawners
 			
 			var buttons = new List<ItemButton>();
 			// `0` corresponds to ItemID.None - that is, no item.
-			for (int k = ItemID.IronPickaxe; k < ItemLoader.ItemCount; k++)
+			for (int k = 1; k < ItemLoader.ItemCount; k++)
 			{
 				var item = new Item();
 				item.SetDefaults(k);

--- a/Content/Tools/Spawners/ItemSpawner.cs
+++ b/Content/Tools/Spawners/ItemSpawner.cs
@@ -8,6 +8,7 @@ using Microsoft.Xna.Framework.Graphics;
 using System.Collections.Generic;
 using System.Linq;
 using Terraria;
+using Terraria.ID;
 using Terraria.ModLoader;
 using Terraria.ModLoader.UI.Elements;
 using Terraria.UI;
@@ -46,7 +47,8 @@ namespace DragonLens.Content.Tools.Spawners
 		public override void PopulateGrid(UIGrid grid)
 		{
 			var buttons = new List<ItemButton>();
-			for (int k = 0; k < ItemLoader.ItemCount; k++)
+			// `0` corresponds to ItemID.None - that is, no item.
+			for (int k = ItemID.IronPickaxe; k < ItemLoader.ItemCount; k++)
 			{
 				var item = new Item();
 				item.SetDefaults(k);

--- a/Content/Tools/Spawners/NPCSpawner.cs
+++ b/Content/Tools/Spawners/NPCSpawner.cs
@@ -10,6 +10,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Terraria;
 using Terraria.GameContent.Bestiary;
+using Terraria.ID;
 using Terraria.ModLoader;
 using Terraria.ModLoader.UI.Elements;
 using Terraria.UI;
@@ -52,7 +53,8 @@ namespace DragonLens.Content.Tools.Spawners
 		public override void PopulateGrid(UIGrid grid)
 		{
 			var buttons = new List<NPCButton>();
-			for (int k = 0; k < NPCLoader.NPCCount; k++)
+			// `0` corresponds to NPCID.None - that is, no NPC.
+			for (int k = NPCID.BlueSlime; k < NPCLoader.NPCCount; k++)
 			{
 				var npc = new NPC();
 				npc.SetDefaults_ForNetId(k, 1);

--- a/Content/Tools/Spawners/NPCSpawner.cs
+++ b/Content/Tools/Spawners/NPCSpawner.cs
@@ -54,7 +54,7 @@ namespace DragonLens.Content.Tools.Spawners
 		{
 			var buttons = new List<NPCButton>();
 			// `0` corresponds to NPCID.None - that is, no NPC.
-			for (int k = NPCID.BlueSlime; k < NPCLoader.NPCCount; k++)
+			for (int k = 1; k < NPCLoader.NPCCount; k++)
 			{
 				var npc = new NPC();
 				npc.SetDefaults_ForNetId(k, 1);

--- a/Content/Tools/Spawners/ProjectileSpawner.cs
+++ b/Content/Tools/Spawners/ProjectileSpawner.cs
@@ -10,6 +10,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Terraria;
+using Terraria.ID;
 using Terraria.ModLoader;
 using Terraria.ModLoader.UI.Elements;
 using Terraria.UI;
@@ -89,7 +90,8 @@ namespace DragonLens.Content.Tools.Spawners
 		public override void PopulateGrid(UIGrid grid)
 		{
 			var buttons = new List<ProjectileButton>();
-			for (int k = 0; k < ProjectileLoader.ProjectileCount; k++)
+			// `0` corresponds to ProjectileID.None - that is, no projectile.
+			for (int k = 1; k < ProjectileLoader.ProjectileCount; k++)
 			{
 				var proj = new Projectile();
 				proj.SetDefaults(k);

--- a/Content/Tools/Spawners/TileSpawner.cs
+++ b/Content/Tools/Spawners/TileSpawner.cs
@@ -56,7 +56,7 @@ namespace DragonLens.Content.Tools.Spawners
 			var buttons = new List<TileButton>();
 			// Unlike a lot of content, `0` actually corresponds to TileID.Dirt,
 			// so that works out fine.
-			for (int k = TileID.Dirt; k < TileLoader.TileCount; k++)
+			for (int k = 0; k < TileLoader.TileCount; k++)
 			{
 				buttons.Add(new TileButton(k, this));
 			}

--- a/Content/Tools/Spawners/TileSpawner.cs
+++ b/Content/Tools/Spawners/TileSpawner.cs
@@ -54,7 +54,9 @@ namespace DragonLens.Content.Tools.Spawners
 		public override void PopulateGrid(UIGrid grid)
 		{
 			var buttons = new List<TileButton>();
-			for (int k = 0; k < TileLoader.TileCount; k++)
+			// Unlike a lot of content, `0` actually corresponds to TileID.Dirt,
+			// so that works out fine.
+			for (int k = TileID.Dirt; k < TileLoader.TileCount; k++)
 			{
 				buttons.Add(new TileButton(k, this));
 			}


### PR DESCRIPTION
*Resolves #18, resolves #24.*

Fixes some issues where loops for some spawners started at `0` instead of `1`.

Also added a filter for deprecated items as well as support for obtaining them.