### PR TITLE
Fix customization elements disappearing when changing UI scale

### DIFF
--- a/Content/GUI/ToolbarCustomizationElements.cs
+++ b/Content/GUI/ToolbarCustomizationElements.cs
@@ -27,7 +27,6 @@ namespace DragonLens.Content.GUI
 		{
 			parent.parent.toolbar.toolList.Remove(parent.tool);
 			UILoader.GetUIState<ToolbarState>().Refresh();
-			UILoader.GetUIState<ToolbarState>().Customize();
 		}
 
 		public override void Draw(SpriteBatch spriteBatch)
@@ -99,7 +98,6 @@ namespace DragonLens.Content.GUI
 		{
 			ToolbarHandler.activeToolbars.Remove(Toolbar);
 			UILoader.GetUIState<ToolbarState>().Refresh();
-			UILoader.GetUIState<ToolbarState>().Customize();
 		}
 
 		public override void Draw(SpriteBatch spriteBatch)
@@ -312,7 +310,6 @@ namespace DragonLens.Content.GUI
 			ToolbarHandler.activeToolbars.Add(new Toolbar(new Vector2(0.5f, 0.6f), Orientation.Horizontal, Main.mapFullscreen ? AutomaticHideOption.NoMapScreen : AutomaticHideOption.Never));
 
 			UILoader.GetUIState<ToolbarState>().Refresh();
-			UILoader.GetUIState<ToolbarState>().Customize();
 		}
 
 		public override void Draw(SpriteBatch spriteBatch)

--- a/Content/GUI/ToolbarState.cs
+++ b/Content/GUI/ToolbarState.cs
@@ -38,6 +38,9 @@ namespace DragonLens.Content.GUI
 				Append(element);
 			}
 
+			if (CustomizeTool.customizing)
+				Customize();
+
 			Recalculate();
 		}
 

--- a/Content/Tools/CustomizeTool.cs
+++ b/Content/Tools/CustomizeTool.cs
@@ -130,7 +130,6 @@ namespace DragonLens.Content.Tools
 			ToolBrowser.TrackedToolbar.AddTool(tool);
 
 			UILoader.GetUIState<ToolbarState>().Refresh();
-			UILoader.GetUIState<ToolbarState>().Customize();
 		}
 
 		public override int CompareTo(object obj)


### PR DESCRIPTION
Fixed a bug where having the customize tool enabled and changing the UI scale would cause the save/load/new bar elements to permanently disappear.