### PR TITLE
Fix toolbar collapsing

### DIFF
--- a/Content/GUI/ToolbarCustomizationElements.cs
+++ b/Content/GUI/ToolbarCustomizationElements.cs
@@ -203,6 +203,7 @@ namespace DragonLens.Content.GUI
 					DraggedToolbar.orientation = Orientation.Horizontal;
 				}
 
+				DraggedToolbar.collapsed = false;
 				draggedElement.Refresh();
 			}
 		}

--- a/Content/GUI/ToolbarElements.cs
+++ b/Content/GUI/ToolbarElements.cs
@@ -70,12 +70,40 @@ namespace DragonLens.Content.GUI
 			}
 
 			Recalculate();
+			UpdateTargetOffset();
+			offset = offsetTarget;
 			AdjustDimensions();
 			AddCollapseTab();
 
 			Recalculate();
 
 			basePos = GetDimensions().Position();
+		}
+
+		public void UpdateTargetOffset()
+		{
+			switch (toolbar.CollapseDirection)
+			{
+				case CollapseDirection.Left:
+					offsetTarget = new Vector2(toolbar.collapsed ? -62 : 0, 0);
+					break;
+
+				case CollapseDirection.Right:
+					offsetTarget = new Vector2(toolbar.collapsed ? 62 : 0, 0);
+					break;
+
+				case CollapseDirection.Up:
+					offsetTarget = new Vector2(0, toolbar.collapsed ? -62 : 0);
+					break;
+
+				case CollapseDirection.Down:
+					offsetTarget = new Vector2(0, toolbar.collapsed ? 62 : 0);
+					break;
+
+				case CollapseDirection.Floating:
+					offsetTarget = Vector2.Zero;
+					break;
+			}
 		}
 
 		/// <summary>
@@ -301,31 +329,10 @@ namespace DragonLens.Content.GUI
 			if (CustomizeTool.customizing)
 				return;
 
-			Toolbar.collapsed = !Toolbar.collapsed;
+			if (Toolbar.CollapseDirection != CollapseDirection.Floating)
+				Toolbar.collapsed = !Toolbar.collapsed;
 
-			switch (Toolbar.CollapseDirection)
-			{
-				case CollapseDirection.Left:
-					parent.offsetTarget = new Vector2(Toolbar.collapsed ? -62 : 0, 0);
-					break;
-
-				case CollapseDirection.Right:
-					parent.offsetTarget = new Vector2(Toolbar.collapsed ? 62 : 0, 0);
-					break;
-
-				case CollapseDirection.Up:
-					parent.offsetTarget = new Vector2(0, Toolbar.collapsed ? -62 : 0);
-					break;
-
-				case CollapseDirection.Down:
-					parent.offsetTarget = new Vector2(0, Toolbar.collapsed ? 62 : 0);
-					break;
-
-				case CollapseDirection.Floating:
-
-					break;
-			}
-
+			parent.UpdateTargetOffset();
 			parent.Recalculate();
 		}
 


### PR DESCRIPTION
Fixes a few issues with collapsing toolbars.

Issue: Floating toolbars could be "silently" collapsed. (`Toolbar.collapsed` would toggle, but nothing visually would happen)
Solution: Forced `collapsed` to only be changed if the toolbar is not floating.

Issue: Refreshing the toolbar visually uncollapses all toolbars, even though `collapsed` is still true
Solution: Updated `offset` and `offsetTarget` in `ToolbarElement.Refresh`.

Issue: Dragging a collapsed toolbar would not change `offsetTarget`
Solution: Set `collapsed` to false when dragging so `offsetTarget` gets set properly. `offsetTarget` is also set to zero if the toolbar is floating.
