### PR TITLE
Fix toolbars going offscreen when changing orientation

### DIFF
--- a/Content/GUI/ToolbarCustomizationElements.cs
+++ b/Content/GUI/ToolbarCustomizationElements.cs
@@ -179,25 +179,22 @@ namespace DragonLens.Content.GUI
 				DraggedToolbar.relativePosition.X = MathHelper.Clamp(Main.MouseScreen.X / Main.screenWidth, 0 + relW / 2, 1 - relW / 2);
 				DraggedToolbar.relativePosition.Y = MathHelper.Clamp(Main.MouseScreen.Y / Main.screenHeight, 0 + relH / 2, 1 - relH / 2);
 
-				if (Main.MouseScreen.X / Main.screenWidth < 0.025f)
+				if (Main.MouseScreen.X / Main.screenWidth < 0.025f && draggedElement.Width.Pixels < Main.screenHeight)
 				{
 					DraggedToolbar.relativePosition.X = 0;
 					DraggedToolbar.orientation = Orientation.Vertical;
 				}
-
-				if (Main.MouseScreen.X / Main.screenWidth > 0.975f)
+				else if (Main.MouseScreen.X / Main.screenWidth > 0.975f && draggedElement.Width.Pixels < Main.screenHeight)
 				{
 					DraggedToolbar.relativePosition.X = 1;
 					DraggedToolbar.orientation = Orientation.Vertical;
 				}
-
-				if (Main.MouseScreen.Y / Main.screenHeight < 0.025f)
+				else if (Main.MouseScreen.Y / Main.screenHeight < 0.025f && draggedElement.Height.Pixels < Main.screenWidth)
 				{
 					DraggedToolbar.relativePosition.Y = 0;
 					DraggedToolbar.orientation = Orientation.Horizontal;
 				}
-
-				if (Main.MouseScreen.Y / Main.screenHeight > 0.975f)
+				else if (Main.MouseScreen.Y / Main.screenHeight > 0.975f && draggedElement.Height.Pixels < Main.screenWidth)
 				{
 					DraggedToolbar.relativePosition.Y = 1;
 					DraggedToolbar.orientation = Orientation.Horizontal;


### PR DESCRIPTION
Issue: A horizontal toolbar is not guaranteed to fit as a vertical toolbar and if this happens the toolbar can go partially offscreen
Solution: Prevented toolbars from changing orientation if they don't fix on screen in the new orientation

Issue: Moving a toolbar to a corner causes the panel to go partially offscreen
Solution: Made `relativePosition.X` = 0 or 1 mutually exclusive with `relativePosition.Y` = 0 or 1 since currently there is no support for horizontal toolbars clamped to left/right side or vertical toolbars clamped to top/bottom