### PR TITLE
Fix game exit issues

### DIFF
--- a/Content/Tools/Spawners/NPCSpawner.cs
+++ b/Content/Tools/Spawners/NPCSpawner.cs
@@ -40,7 +40,9 @@ namespace DragonLens.Content.Tools.Spawners
 
 			if (Main.netMode == NetmodeID.Server && sender >= 0)
 			{
-				NPCBrowser.selected.type = type;
+				if(NPCBrowser.selected != null)
+					NPCBrowser.selected.type = type;
+
 				Main.mouseX = (int)pos.X;
 				Main.mouseY = (int)pos.Y;
 				NetSend(-1, sender);

--- a/Content/Tools/Spawners/ProjectileSpawner.cs
+++ b/Content/Tools/Spawners/ProjectileSpawner.cs
@@ -52,9 +52,13 @@ namespace DragonLens.Content.Tools.Spawners
 
 			if (Main.netMode == NetmodeID.Server && sender >= 0)
 			{
-				ProjectileBrowser.selected.type = type;
-				ProjectileBrowser.selected.damage = damage;
-				ProjectileBrowser.selected.knockBack = knockBack;
+				if(ProjectileBrowser.selected != null)
+				{
+					ProjectileBrowser.selected.type = type;
+					ProjectileBrowser.selected.damage = damage;
+					ProjectileBrowser.selected.knockBack = knockBack;
+				}
+				
 				Main.mouseX = (int)pos.X;
 				Main.mouseY = (int)pos.Y;
 

--- a/Core/Systems/ToolSystem/ToolHandler.cs
+++ b/Core/Systems/ToolSystem/ToolHandler.cs
@@ -116,7 +116,7 @@ namespace DragonLens.Core.Systems.ToolSystem
 		/// </summary>
 		public override void OnModLoad()
 		{
-			if (Main.netMode == NetmodeID.Server)
+			if (Main.netMode != NetmodeID.SinglePlayer)
 				return;
 
 			CreateOrLoadData();

--- a/DragonLens.cs
+++ b/DragonLens.cs
@@ -56,6 +56,7 @@ namespace DragonLens
 					watch.Stop();
 					Logger.Info($"Item assets finished loading in {watch.ElapsedMilliseconds} ms");
 				});
+				itemThread.IsBackground = true;
 				itemThread.Start();
 
 				var projThread = new Thread(() =>
@@ -71,6 +72,7 @@ namespace DragonLens
 					watch.Stop();
 					Logger.Info($"Projectile assets finished loading in {watch.ElapsedMilliseconds} ms");
 				});
+				projThread.IsBackground = true;
 				projThread.Start();
 
 				var npcThread = new Thread(() =>
@@ -86,6 +88,7 @@ namespace DragonLens
 					watch.Stop();
 					Logger.Info($"NPC assets finished loading in {watch.ElapsedMilliseconds} ms");
 				});
+				npcThread.IsBackground = true;
 				npcThread.Start();
 
 				var tileThread = new Thread(() =>
@@ -101,6 +104,7 @@ namespace DragonLens
 					watch.Stop();
 					Logger.Info($"Tile assets finished loading in {watch.ElapsedMilliseconds} ms");
 				});
+				tileThread.IsBackground = true;
 				tileThread.Start();
 			}
 		}


### PR DESCRIPTION
Issue: In multiplayer the server would crash when exiting tModLoader.
Solution: Added null checks in `RecievePacket` and changed to `Main.netMode != NetmodeID.SinglePlayer` in `ToolHandler.OnModLoader`

Issue: tModLoader would fail to exit properly if the threads used to `preloadAssets` did not finish. The `itemThread` was particularly problematic taking upwards of 90 seconds to complete and forcing a process termination before tModLoader could be started again.
Solution: Made them background threads to prevent orphan threads