### PR TITLE
Paint Tool & Buff Despawner Bug Fix + Various UI Optimization

### DIFF
--- a/Content/Tools/Despawners/BuffDespawner.cs
+++ b/Content/Tools/Despawners/BuffDespawner.cs
@@ -15,7 +15,8 @@ namespace DragonLens.Content.Tools.Despawners
 		{
 			for (int k = 0; k < Player.MaxBuffs; k++)
 			{
-				Main.LocalPlayer.DelBuff(k);
+				Main.LocalPlayer.buffTime[k] = 0;
+				Main.LocalPlayer.buffType[k] = 0;
 			}
 		}
 	}

--- a/Content/Tools/Gameplay/Paint.cs
+++ b/Content/Tools/Gameplay/Paint.cs
@@ -166,7 +166,7 @@ namespace DragonLens.Content.Tools.Gameplay
 			if (selecting || structure != null)
 				Main.LocalPlayer.mouseInterface = true;
 
-			if (Main.mouseLeft && structure != null)
+			if (Main.mouseLeft && structure != null && !BoundingBox.Contains(Main.MouseScreen.ToPoint()))
 			{
 				//Prevents re-placing the same structure in the same place which could cause lag
 				if (PlaceTarget != lastPlaced)
@@ -258,7 +258,13 @@ namespace DragonLens.Content.Tools.Gameplay
 			this.parent = parent;
 			strucutre = tag;
 
+			// StructurePreview constructor requires a spritebatch to be active
+			Main.spriteBatch.Begin();
+
 			preview = new("Temporary structure " + strucutre.GetHashCode(), tag);
+
+			// End the spritebatch after the preview is created
+			Main.spriteBatch.End();
 
 			Width.Set(140, 0);
 			Height.Set(140, 0);

--- a/Content/Tools/Spawners/BuffSpawner.cs
+++ b/Content/Tools/Spawners/BuffSpawner.cs
@@ -166,31 +166,36 @@ namespace DragonLens.Content.Tools.Spawners
 
 				float alpha = 0.5f;
 
-				PlayerInput.SetZoom_World();
-
-				spriteBatch.End();
-				spriteBatch.Begin(default, default, default, default, default, default, Main.GameViewMatrix.TransformationMatrix);
-
-				foreach (NPC npc in Main.npc)
+				if (!BoundingBox.Contains(Main.MouseScreen.ToPoint()) && !filters.IsMouseHovering && !durationEditor.IsMouseHovering)
 				{
-					Rectangle clickbox = npc.Hitbox;
-					clickbox.Inflate(32, 32);
 
-					if (clickbox.Contains(Main.MouseWorld.ToPoint()))
+					PlayerInput.SetZoom_World();
+
+					spriteBatch.End();
+					spriteBatch.Begin(default, default, default, default, default, default,
+						Main.GameViewMatrix.TransformationMatrix);
+
+					foreach (NPC npc in Main.npc)
 					{
-						alpha = 1;
-						Rectangle offset = clickbox;
-						offset.Offset((-Main.screenPosition).ToPoint());
-						Helpers.GUIHelper.DrawOutline(spriteBatch, offset, Color.Red);
+						Rectangle clickbox = npc.Hitbox;
+						clickbox.Inflate(32, 32);
 
-						break;
+						if (clickbox.Contains(Main.MouseWorld.ToPoint()))
+						{
+							alpha = 1;
+							Rectangle offset = clickbox;
+							offset.Offset((-Main.screenPosition).ToPoint());
+							Helpers.GUIHelper.DrawOutline(spriteBatch, offset, Color.Red);
+
+							break;
+						}
 					}
+
+					spriteBatch.End();
+					spriteBatch.Begin(default, default, default, default, default, default, Main.UIScaleMatrix);
+
+					PlayerInput.SetZoom_UI();
 				}
-
-				spriteBatch.End();
-				spriteBatch.Begin(default, default, default, default, default, default, Main.UIScaleMatrix);
-
-				PlayerInput.SetZoom_UI();
 
 				spriteBatch.Draw(tex, Main.MouseScreen + Vector2.One * 8, new Rectangle(0, 0, tex.Width, tex.Height), Color.White * alpha, 0, default, 1, 0, 0);
 			}

--- a/Content/Tools/Spawners/DustSpawner.cs
+++ b/Content/Tools/Spawners/DustSpawner.cs
@@ -129,7 +129,7 @@ namespace DragonLens.Content.Tools.Spawners
 			{
 				Main.LocalPlayer.mouseInterface = true;
 
-				if (Main.mouseLeft)
+				if (Main.mouseLeft && !BoundingBox.Contains(Main.MouseScreen.ToPoint()) && !perfectEditor.IsMouseHovering && !scaleEditor.IsMouseHovering && !alphaEditor.IsMouseHovering && !velocityEditor.IsMouseHovering && !colorEditor.IsMouseHovering)
 				{
 					PlayerInput.SetZoom_World();
 

--- a/Content/Tools/Spawners/NPCSpawner.cs
+++ b/Content/Tools/Spawners/NPCSpawner.cs
@@ -111,7 +111,7 @@ namespace DragonLens.Content.Tools.Spawners
 		{
 			base.SafeClick(evt);
 
-			if (selected != null)
+			if (selected != null && !BoundingBox.Contains(Main.MouseScreen.ToPoint()) && !filters.IsMouseHovering)
 			{
 				PlayerInput.SetZoom_World();
 				NPC.NewNPC(null, (int)Main.MouseWorld.X, (int)Main.MouseWorld.Y, selected.type);

--- a/Content/Tools/Spawners/ProjectileSpawner.cs
+++ b/Content/Tools/Spawners/ProjectileSpawner.cs
@@ -32,6 +32,7 @@ namespace DragonLens.Content.Tools.Spawners
 			writer.WriteVector2(ProjectileBrowser.velocity);
 			writer.Write(ProjectileBrowser.ai0);
 			writer.Write(ProjectileBrowser.ai1);
+			writer.Write(ProjectileBrowser.ai2);
 		}
 
 		public override void RecievePacket(BinaryReader reader, int sender)
@@ -44,6 +45,7 @@ namespace DragonLens.Content.Tools.Spawners
 			Vector2 velocity = reader.ReadVector2();
 			float ai0 = reader.ReadSingle();
 			float ai1 = reader.ReadSingle();
+			float ai2 = reader.ReadSingle();
 
 			Projectile.NewProjectile(null, Main.MouseWorld, velocity, type, damage, knockBack, Main.myPlayer, ai0, ai1);
 
@@ -62,6 +64,7 @@ namespace DragonLens.Content.Tools.Spawners
 				ProjectileBrowser.velocity = velocity;
 				ProjectileBrowser.ai0 = ai0;
 				ProjectileBrowser.ai1 = ai1;
+				ProjectileBrowser.ai2 = ai2;
 
 				NetSend(-1, sender);
 			}
@@ -81,6 +84,9 @@ namespace DragonLens.Content.Tools.Spawners
 		public static float ai1;
 		public static FloatEditor ai1Editor;
 
+		public static float ai2;
+		public static FloatEditor ai2Editor;
+
 		public override string Name => "Projectile spawner";
 
 		public override string IconTexture => "ProjectileSpawner";
@@ -97,6 +103,9 @@ namespace DragonLens.Content.Tools.Spawners
 
 			ai1Editor = new("ai 1", n => ai1 = n, 0);
 			Append(ai1Editor);
+
+			ai2Editor = new("ai 2", n => ai2 = n, 0);
+			Append(ai2Editor);
 		}
 
 		public override void AdjustPositions(Vector2 newPos)
@@ -115,6 +124,10 @@ namespace DragonLens.Content.Tools.Spawners
 
 			ai1Editor.Left.Set(newPos.X - 160, 0);
 			ai1Editor.Top.Set(newPos.Y + nextY, 0);
+			nextY += ai1Editor.Height.Pixels + 4;
+
+			ai2Editor.Left.Set(newPos.X - 160, 0);
+			ai2Editor.Top.Set(newPos.Y + nextY, 0);
 		}
 
 		public override void PopulateGrid(UIGrid grid)
@@ -159,10 +172,10 @@ namespace DragonLens.Content.Tools.Spawners
 		{
 			base.SafeClick(evt);
 
-			if (selected != null)
+			if (selected != null && !BoundingBox.Contains(Main.MouseScreen.ToPoint()) && !filters.IsMouseHovering && !velocityEditor.IsMouseHovering && !ai0Editor.IsMouseHovering && !ai1Editor.IsMouseHovering && !ai2Editor.IsMouseHovering)
 			{
 				PlayerInput.SetZoom_World();
-				Projectile.NewProjectile(null, Main.MouseWorld, velocity, selected.type, selected.damage, selected.knockBack, Main.myPlayer, ai0, ai1);
+				Projectile.NewProjectile(null, Main.MouseWorld, velocity, selected.type, selected.damage, selected.knockBack, Main.myPlayer, ai0, ai1, ai2);
 				ToolHandler.NetSend<ProjectileSpawner>();
 				PlayerInput.SetZoom_UI();
 			}
@@ -244,7 +257,7 @@ namespace DragonLens.Content.Tools.Spawners
 
 		public override void SafeRightClick(UIMouseEvent evt)
 		{
-			Projectile.NewProjectile(null, Main.LocalPlayer.Center, ProjectileBrowser.velocity, proj.type, proj.damage, proj.knockBack, Main.myPlayer, ProjectileBrowser.ai0, ProjectileBrowser.ai1);
+			Projectile.NewProjectile(null, Main.LocalPlayer.Center, ProjectileBrowser.velocity, proj.type, proj.damage, proj.knockBack, Main.myPlayer, ProjectileBrowser.ai0, ProjectileBrowser.ai1, ProjectileBrowser.ai2);
 		}
 
 		public override int CompareTo(object obj)

--- a/Content/Tools/Spawners/TileSpawner.cs
+++ b/Content/Tools/Spawners/TileSpawner.cs
@@ -62,7 +62,7 @@ namespace DragonLens.Content.Tools.Spawners
 		{
 			base.DraggableUdpate(gameTime);
 
-			if (Main.mouseLeft && selected != -1)
+			if (Main.mouseLeft && selected != -1 && !BoundingBox.Contains(Main.MouseScreen.ToPoint()) && !filters.IsMouseHovering)
 			{
 				PlayerInput.SetZoom_World();
 

--- a/Core/Systems/FirstTimeSetupSystem.cs
+++ b/Core/Systems/FirstTimeSetupSystem.cs
@@ -87,12 +87,13 @@ namespace DragonLens.Core.Systems
 					.AddTool<ItemDespawner>()
 					.AddTool<ProjectileDespawner>()
 					.AddTool<NPCDespawner>()
+					.AddTool<BuffDespawner>()
 					.AddTool<GoreDespawner>()
 					.AddTool<DustDespawner>()
 					);
 
 				n.Add(
-					new Toolbar(new Vector2(0.5f, 1f), Orientation.Horizontal, AutomaticHideOption.Never)
+					new Toolbar(new Vector2(0.45f, 1f), Orientation.Horizontal, AutomaticHideOption.Never)
 					.AddTool<Godmode>()
 					.AddTool<InfiniteReach>()
 					.AddTool<NoClip>()
@@ -109,7 +110,7 @@ namespace DragonLens.Core.Systems
 					);
 
 				n.Add(
-					new Toolbar(new Vector2(0.7f, 1f), Orientation.Horizontal, AutomaticHideOption.Never)
+					new Toolbar(new Vector2(0.75f, 1f), Orientation.Horizontal, AutomaticHideOption.Never)
 					.AddTool<Floodlight>()
 					.AddTool<Hitboxes>()
 					.AddTool<FreeCamera>()


### PR DESCRIPTION
### Related issues
Implemented #57 partly (Added "Clear Buffs" tool to Advanced preset)
Fixed #54 

### Fix buff despawner not removing all buffs
Previously, `DelBuff()` is used in buff despawner:
```CSharp
for (int k = 0; k < Player.MaxBuffs; k++)
{
	Main.LocalPlayer.DelBuff(k);
}
```
Since `DelBuff()` shuffles the remaining buff indexes down to fill the gap. Doing this only removes half of the buffs actually

I fixed it by directly setting `buffTime` and `buffType`
```CSharp
for (int k = 0; k < Player.MaxBuffs; k++)
{
	Main.LocalPlayer.buffTime[k] = 0;
	Main.LocalPlayer.buffType[k] = 0;
}
```

### Advanced preset optimization
If your PC resolution is 1920x1080 and your ui scale is 100%, these two toolbars in Advanced preset overlap:
![OCSR }~`TB(QW}_@ Y }S7Y](https://user-images.githubusercontent.com/35227653/235615200-c0a4c988-eee3-4e65-add7-71b1b68e8ac1.png)
Considering that many people have the same resolution and ui scale settings as me, I made a slight change to fix this:
![KWVH)D3HX(6V0Z_$B6YLZHH](https://user-images.githubusercontent.com/35227653/235615253-25d08a4d-ad7d-4c90-9fb3-decad328d250.png)

### Clicking on a UI panel no longer spawns your selection
Before:
![dotnet_Ol8BVNHyJt](https://user-images.githubusercontent.com/35227653/235616017-f19bce33-46b3-488f-ad39-29e76bf8f8f2.gif)
After:
![dotnet_QOMAsqQYj7](https://user-images.githubusercontent.com/35227653/235616038-c08c3397-497a-4f4a-931b-c1544be5903e.gif)

Other spawner tools are fixed as well

### `ai2` option for projectile spawner
1.4.4 added `Projectile.ai[2]`, which should be an option for projectile spawner.
![image](https://user-images.githubusercontent.com/35227653/235616412-245ab5d2-1a9e-4e52-9da5-b216b94aa3f2.png)
