### PR TITLE
Fix crash with WorldGen Preview

### DIFF
--- a/Content/GUI/ToolbarState.cs
+++ b/Content/GUI/ToolbarState.cs
@@ -178,8 +178,9 @@ namespace DragonLens.Content.GUI
 
 			PlayerInput.SetZoom_UI();
 
-			UILoader.GetUIState<ToolbarState>().UserInterface.Update(Main._drawInterfaceGameTime);
-			UILoader.GetUIState<ToolBrowser>().UserInterface.Update(Main._drawInterfaceGameTime); //We update/draw the tool browser here too to ease customization
+			// Have to check if _drawInterfaceGameTime is null otherwise there is a crash with world gen preview mod
+			UILoader.GetUIState<ToolbarState>().UserInterface.Update(Main._drawInterfaceGameTime ?? new GameTime());
+			UILoader.GetUIState<ToolBrowser>().UserInterface.Update(Main._drawInterfaceGameTime ?? new GameTime()); //We update/draw the tool browser here too to ease customization
 
 			Main.spriteBatch.Begin(default, default, default, default, default, default, Main.UIScaleMatrix);
 			UILoader.GetUIState<ToolbarState>().Draw(Main.spriteBatch);


### PR DESCRIPTION
When using with WorldGen preview there is a null ref crash since sometimes a GameTime variable used in a UIState isn't initialized until a world is loaded. WorldGen preview uses the in game map ui, which DragonLens has a ui state on, so the gametime variable isn't initialized yet. This causes a crash when a world is generated.