### PR TITLE
Disable player's gfx Y offset when in noclip

### DIFF
--- a/Content/Tools/Gameplay/Noclip.cs
+++ b/Content/Tools/Gameplay/Noclip.cs
@@ -112,6 +112,7 @@ namespace DragonLens.Content.Tools.Gameplay
 
 				Player.Center = desiredPos;
 				Player.velocity *= 0;
+				Player.gfxOffY = 0;
 			}
 		}
 	}


### PR DESCRIPTION
This shit is so annoying, I was just setting gfxOffY to 0 myself in my own project but I'd rather it just work in dragonlens.